### PR TITLE
Empty 'name' by default to allow a simple 'upgrade'

### DIFF
--- a/SPECS/ansible/tdnf.py
+++ b/SPECS/ansible/tdnf.py
@@ -305,7 +305,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default="present", choices=choices),
-            name=dict(type="list", elements="str", aliases=["pkg"]),
+            name=dict(type="list", default=[], elements="str", aliases=["pkg"]),
             update_cache=dict(default=False, type="bool"),
             upgrade=dict(default=False, type="bool"),
             enablerepo=dict(type="list", default=[], elements="str"),


### PR DESCRIPTION
Hello,

This Ansible module doesn't allow usage without `name:`. This is however necessary when one wants to upgrade existing packages without installing any. i.e. :
```
tdnf:
        upgrade: yes
```